### PR TITLE
Fix redirect path for unmatched routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function App() {
               <Route path="scanner" element={<Scanner />} />
               <Route path="tasks" element={<Tasks />} />
             </Route>
-            <Route path="*" element={<Navigate to="/\" replace />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </AuthProvider>
       </AppProvider>


### PR DESCRIPTION
## Summary
- fix a typo in the fallback `Navigate` route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68405224927083339bc85cd4d3977f22